### PR TITLE
🩹 Minor fixes for Cloud Engine

### DIFF
--- a/docs/sdk/16-engine/02-deploy/01-getting-started.md
+++ b/docs/sdk/16-engine/02-deploy/01-getting-started.md
@@ -99,11 +99,9 @@ func Index(c echo.Context) error {
 
 在确保所有的依赖都正确安装之后，就可以在项目根目录用我们的命令行工具来启动本地运行了：
 
-<pre>
 <CodeBlock className='sh'>
 {`$ ${CLI_BINARY} up`}
 </CodeBlock>
-</pre>
 
 更多有关命令行工具和本地调试的内容请看 [云引擎命令行工具使用指南](/sdk/engine/cli/)。
 

--- a/docs/sdk/16-engine/02-deploy/02-platform.md
+++ b/docs/sdk/16-engine/02-deploy/02-platform.md
@@ -33,7 +33,6 @@ import CodeBlock from '@theme/CodeBlock';
 
 <p>要将一个已有的项目关联到云引擎应用，可以使用 <code>{CLI_BINARY} switch</code>：</p>
 
-<pre>
 <CodeBlock>
 {`$ ${CLI_BINARY} switch
 [?] Please select an app:
@@ -41,7 +40,6 @@ import CodeBlock from '@theme/CodeBlock';
  => 1
 Switching to my-engine-app (group: web)`}
 </CodeBlock>
-</pre>
 
 ## 查看日志
 
@@ -97,11 +95,9 @@ Switching to my-engine-app (group: web)`}
 
 在你的项目根目录运行：
 
-<pre>
 <CodeBlock className='sh'>
 {`${CLI_BINARY} deploy`}
 </CodeBlock>
-</pre>
 
 就会开始上传本地的代码，体验版云引擎会直接部署到生产环境；标准版云引擎则会先部署到一个与生产环境几乎完全相同的预备环境以供测试。
 

--- a/docs/sdk/16-engine/02-deploy/06-java.md
+++ b/docs/sdk/16-engine/02-deploy/06-java.md
@@ -64,11 +64,9 @@ java.runtime.version=11
 
 在本地构建（如使用 `mvn package`）出 WAR 包后，可以在使用命令行工具部署时添加 `--war` 选项表示上传 WAR 包而不是源代码：
 
-<pre>
 <CodeBlock className='sh'>
 {`${CLI_BINARY} deploy --war`}
 </CodeBlock>
-</pre>
 
 这种情况下在云端不会有安装依赖和构建的过程，WAR 包会被直接放入 Servlet 容器运行。
 

--- a/docs/sdk/16-engine/03-functions/01-getting-started.md
+++ b/docs/sdk/16-engine/03-functions/01-getting-started.md
@@ -106,13 +106,11 @@ Hook 的编写和云函数很类似，在后文中我们会详细介绍云函数
 
 <p>可以使用 <code>{CLI_BINARY} up</code> 进行本地运行和调试，命令行工具会自动注入关联应用的环境变量，让云函数可以访问到线上数据存储中的数据。</p>
 
-<pre>
 <CodeBlock className='sh'>
 {`$ ${CLI_BINARY} up
 [INFO] The project is running at: http://localhost:3000
 [INFO] Cloud function debug console (if available) is accessible at: http://localhost:3001`}
 </CodeBlock>
-</pre>
 
 <p><code>{CLI_BINARY} up</code> 同时默认在 3001 端口启动了一个用于调试云函数的控制台（<a href='http://localhost:3001'>http://localhost:3001</a>），开发者可以通过这个控制台来调试云函数和 Hook，模拟特定的输入。</p>
 

--- a/docs/sdk/16-engine/_partials/leandb-cli-access.mdx
+++ b/docs/sdk/16-engine/_partials/leandb-cli-access.mdx
@@ -4,7 +4,6 @@ import CodeBlock from '@theme/CodeBlock';
 
 <p>使用 <Link to='/sdk/engine/cli'>命令行工具 CLI</Link> 提供的 <code>{CLI_BINARY} db shell</code> 可以打开一个连接到云端 LeanDB 的交互式 shell，用于执行查询：</p>
 
-<pre>
 <CodeBlock>
 {`$ ${CLI_BINARY} db shell mysqldb
 Welcome to the MySQL monitor.
@@ -23,16 +22,13 @@ mysql> select * from users;
 +------+-----------+
 2 rows in set (0.06 sec)`}
 </CodeBlock>
-</pre>
 
 <p>使用 <code>{CLI_BINARY} db proxy</code> 可以将云端 LeanDB 导出到本地的一个端口，供本地的程序或图形化的数据库客户端连接：</p>
 
-<pre>
 <CodeBlock>
 {`$ ${CLI_BINARY} db proxy myredis
 [INFO] Now, you can connect myredis via [redis-cli -h 127.0.0.1 -a hsdt9wIAuKcTZmpg -p 5678]`}
 </CodeBlock>
-</pre>
 
 <p>保持这个终端运行（不要关闭），就可以在本地的 5678 端口访问到云端的 LeanDB 了。你可以使用本地的 GUI 客户端中来浏览操作云端的 LeanDB。在使用 <code>{CLI_BINARY} up</code> 进行开发测试时，也可以使用这个功能连接到云端的 LeanDB，设置环境变量（来自前面 <code>{CLI_BINARY} db proxy</code> 的输出）：</p>
 

--- a/docs/sdk/16-engine/_partials/quick-start-deploy.mdx
+++ b/docs/sdk/16-engine/_partials/quick-start-deploy.mdx
@@ -1,18 +1,8 @@
 import {CLI_BINARY} from '/src/constants/env.ts';
 import CodeBlock from '@theme/CodeBlock';
 
-体验版的应用默认直接部署到生产环境：
+直接部署到生产环境：
 
-<pre>
-<CodeBlock className='sh'>
-{`${CLI_BINARY} deploy`}
-</CodeBlock>
-</pre>
-
-如果是标准版云引擎，需要加上 `--prod 1` 参数，指定部署到生产环境（否则会先部署到预备环境）：
-
-<pre>
 <CodeBlock className='sh'>
 {`${CLI_BINARY} deploy --prod 1`}
 </CodeBlock>
-</pre>

--- a/docs/sdk/16-engine/_partials/quick-start-init.mdx
+++ b/docs/sdk/16-engine/_partials/quick-start-init.mdx
@@ -12,7 +12,6 @@ import CodeBlock from '@theme/CodeBlock';
 
 <p>如果你还没有在控制台创建过应用，请先在控制台创建应用，然后使用 <code>{CLI_BINARY} init</code> 创建项目：</p>
 
-<pre>
 <CodeBlock>
 {`$ ${CLI_BINARY} init
 [?] Please select an app:
@@ -35,7 +34,6 @@ import CodeBlock from '@theme/CodeBlock';
 [INFO] Creating project...
 [INFO] Creating Express succeeded. Please refer to our website http://expressjs.com for documentation about Express`}
 </CodeBlock>
-</pre>
 
 <p><code>{CLI_BINARY} init</code> 会创建一个与你的应用同名的目录，我们 <code>cd {props.appName || 'my-engine-app'}</code> 然后安装项目依赖：</p>
 

--- a/versioned_docs/version-v2/sdk/09-engine/02-guide/12-faq.md
+++ b/versioned_docs/version-v2/sdk/09-engine/02-guide/12-faq.md
@@ -327,7 +327,7 @@ exposeEnvironmentsOnBuild: true
 
 ### 部署更新云引擎会导致服务中断吗？
 
-服务不会中断。在代码部署时，系统会优先启动使用新版本代码的实例，待新实例通过了健康检查，系统修改路由将请求转发至新实例后，再关闭旧版本的实例，让服务保持零中断。 
+服务不会中断。在代码部署时，系统会优先启动使用新版本代码的实例，待新实例通过了健康检查，系统修改路由将请求转发至新实例后，再关闭旧版本的实例，让服务保持零中断。
 
 
 ### 部署时长时间卡在「正在下载和安装依赖」怎么办？
@@ -582,7 +582,7 @@ print(leancloud.User.query.count())
 如果应用不使用云函数和 Hook 功能，那么你可以：
 
 - 在 `leanengine.yaml` 中不指定 `functionsMode`，同时 `/1.1/functions/_ops/metadatas` **返回一个 HTTP `404`** 表示不使用云函数和 Hook 相关的功能；
-- 或者在 `leanengine.yaml` 中指定 `functionsMode` 为 `disabled`。注意，这种情况下，即使应用代码中定义了云函数和 Hook，Hook 也不会生效，云函数调用（通过 SDK 发起远程调用或通过 REST API 向 API 域名发起云函数调用）有可能因为被转发到错误的云引擎分组而失败。 
+- 或者在 `leanengine.yaml` 中指定 `functionsMode` 为 `disabled`。注意，这种情况下，即使应用代码中定义了云函数和 Hook，Hook 也不会生效，云函数调用（通过 SDK 发起远程调用或通过 REST API 向 API 域名发起云函数调用）有可能因为被转发到错误的云引擎分组而失败。
 
 ### 部署中断，提示有同名云函数怎么办？
 
@@ -758,7 +758,7 @@ npm ERR! peer dep missing: graphql@^0.10.0 || ^0.11.0, required by express-graph
 - 如果你的应用目录中含有 `yarn.lock`，那么会使用 `yarn install` 代替 `npm install` 来安装依赖（需要 Node.js 4.8 以上）。
 - 如果你的应用目录中同时包含 `package-lock.json` 和 `yarn.lock`，云引擎会使用 `yarn install`。换言之，`yarn.lock` 优先。
 
-如果不希望使用 `yarn.lock`，请将它们加入 `.gitignore`（Git 部署时）或 `.leanengineignore`（命令行工具部署时）。
+如果不希望使用 `yarn.lock`，请将它们加入 `.gitignore`（Git 部署时）或 `.leanignore`（命令行工具部署时）。
 
 另外，也请注意 `yarn.lock` 中包含了下载依赖的 URL，请选择合适的源，否则可能拖慢云引擎部署。
 
@@ -835,7 +835,7 @@ leancloud:request response(0) +220ms 200 {"results":[{"content":"1","createdAt":
 
 ### Maximum call stack size exceeded 如何解决？
 
-**将 JavaScript SDK 和 Node SDK 升级到 1.2.2 以上版本可以彻底解决该问题。** 
+**将 JavaScript SDK 和 Node SDK 升级到 1.2.2 以上版本可以彻底解决该问题。**
 
 如果你的应用时不时出现 `Maximum call stack size exceeded` 异常，可能是因为在 hook 中调用了 `AV.Object.extend`。有两种方法可以避免这种异常：
 
@@ -976,7 +976,7 @@ app.get('/profile', function (req, res) {
 
 app.get('/logout', function (req, res) {
   req.currentUser.logOut();
-  res.clearCurrentUser(); // clear cookie 
+  res.clearCurrentUser(); // clear cookie
   res.redirect('/profile');
 });
 ```
@@ -997,7 +997,7 @@ AV.Cloud.CookieSession({sameSite: 'none'})
 
 ### 为什么云函数中 include 的字段没有被完整地发给客户端？
 
-> 将 JavaScript SDK 和 Node SDK 升级到 3.0 以上版本可以彻底解决该问题。  
+> 将 JavaScript SDK 和 Node SDK 升级到 3.0 以上版本可以彻底解决该问题。
 
 云函数在响应时会调用到 `AV.Object#toJSON` 方法，将结果序列化为 JSON 对象返回给客户端。在早期版本中 `AV.Object#toJSON` 方法为了防止循环引用，当遇到属性是 Pointer 类型会返回 Pointer 元信息，不会将 include 的其他字段添加进去，我们在 [JavaScript SDK 3.0](https://github.com/leancloud/javascript-sdk/releases/tag/v3.0.0) 中对序列化相关的逻辑做了重新设计，**将 JavaScript SDK 和 Node SDK 升级到 3.0 以上版本便可以彻底解决该问题**。
 
@@ -1019,14 +1019,14 @@ AV.Cloud.define('querySomething', function(req, res) {
 });
 ```
 
-Python SDK 也存在类似的问题，只会返回 Pointer 元信息，因此也需要额外进行一次查询并手动进行序列化。 
+Python SDK 也存在类似的问题，只会返回 Pointer 元信息，因此也需要额外进行一次查询并手动进行序列化。
 
 ### RPC 调用云函数时，为什么会返回预期之外的空对象？
 
 使用 Node SDK 定义的云函数，如果返回一个不是 AVObject 的值，比如字符串、数字，RPC 调用得到的是空对象（`{}`）。
 类似地，如果返回一个包含非 AVObject 成员的数组，RPC 调用的结果中该数组的相应成员也会被序列化为 `{}`。
 这个问题将在 Node SDK 的下一个大版本（4.0）中修复。
-目前绕过这一个问题的方法是将返回结果放在对象（`{}`）中返回。 
+目前绕过这一个问题的方法是将返回结果放在对象（`{}`）中返回。
 
 ### `node --max-http-header-size` 无效？
 
@@ -1181,7 +1181,7 @@ npm install --save leanengine leancloud-storage
 同时也需要自行初始化 SDK（注意我们在云引擎中开启了 masterKey 权限，这将会跳过 ACL 和其他权限限制）：
 
 ```js
-const AV = require('leanengine'); 
+const AV = require('leanengine');
 
 AV.init({
   appId: process.env.LEANCLOUD_APP_ID,


### PR DESCRIPTION
- 代码块样式
- `.leanignore` 的 typo
- 简化快速开始里部署的描述

看完直接合就行。