### PR TITLE
refactor: improve license guide

### DIFF
--- a/docs/sdk/11-lisence/02-guide.md
+++ b/docs/sdk/11-lisence/02-guide.md
@@ -8,25 +8,62 @@ import {Conditional} from '/src/docComponents/conditional';
 import MultiLang from '/src/docComponents/MultiLang';
 import CodeBlock from '@theme/CodeBlock';
 import sdkVersions from '/src/docComponents/sdkVersions';
-import {Gray,Blue, Red, Black} from '/src/docComponents/doc';
 
+正版验证适用于在 TapTap 上架的付费下载游戏。游戏集成 TapSDK 的正版验证之后，当玩家第一次启动游戏时（包含卸载后再次安装），SDK 会前往 TapTap 查询玩家是否购买游戏，如已购买，则可正常进入游戏，如查询到未购买，则会引导购买。
 
-## 正版验证
+## SDK 获取
 
-<Gray>为了游戏售卖服务的功能，避免 APK 流出导致盗版横行；当游戏准备在 TapTap 开放售卖时，可以接入此功能。</Gray>
+可以在 [下载页](/tap-download) 获得 SDK，添加以下依赖：
 
-在项目的 `Packages/manifest.json` 文件中添加以下依赖：
+<MultiLang>
+
+<>
+
+SDK 可以**通过 Unity Package Manger 导入或手动导入**，二者任选其一。
+
+1. 下载 SDK 后即可手动导入。
+2. 如果选择 UPM 导入，可以在项目的 `Packages/manifest.json` 文件中添加：
 
 <CodeBlock className="json">
 {`"dependencies":{
-// 公共库
-"com.taptap.tds.common":"https://github.com/TapTap/TapCommon-Unity.git#${sdkVersions.taptap.unity}",
-// 付费购买
-"com.taptap.tds.dlc": "https://github.com/TapTap/TapLicense-Unity.git#${sdkVersions.taptap.unity}",
+    // 公共库
+    "com.taptap.tds.common":"https://github.com/TapTap/TapCommon-Unity.git#${sdkVersions.taptap.unity}",
+    // 付费购买
+    "com.taptap.tds.dlc": "https://github.com/TapTap/TapLicense-Unity.git#${sdkVersions.taptap.unity}",
 }`}
 </CodeBlock>
 
-### 设置授权回调
+</>
+
+<>
+
+将 SDK 包导入到项目 `project/app/libs` 目录下。打开项目的 `project/app/build.gradle` 文件，添加：
+
+<CodeBlock className="groovy">
+{`repositories{
+    flatDir {  
+        dirs 'libs'  
+    }  
+}  
+dependencies {
+    implementation name:'TapCommon_${sdkVersions.taptap.android}', ext:'aar'
+    implementation name:'TapLicense_${sdkVersions.taptap.android}', ext:'aar'
+}`}
+</CodeBlock>
+
+</>
+
+<>
+
+```objc
+// 暂不支持
+```
+
+</>
+
+</MultiLang>
+
+## 设置授权回调
 
 <MultiLang>
 
@@ -58,9 +95,10 @@ TapLicenseHelper.setLicenseCallback(new TapLicenseCallback() {
 ```objc
 // 暂不支持
 ```
+
 </MultiLang>
 
-### 检查付费授权
+## 检查是否付费
 
 <MultiLang>
 
@@ -75,60 +113,71 @@ TapLicenseHelper.check(Activity activity);
 ```objc
 // 暂不支持
 ```
+
 </MultiLang>
 
 ## 测试
 
-为了保证上线后，游戏对于用户是否购买的判断能够正常生效，**请务必按照以下说明完成自测。**
+为了保证上线后，正版验证服务能够正常生效，**请务必按照以下说明完成自测。**
 
-### 上传 APK
+#### 1.上传 APK
 
-上传需要测试的 APK 至开发者中心，并通过审核。
+前往开发者中心选择需要测试的游戏，依次转入**游戏服务 > 生态服务 > 正版验证 > 游戏配置 > 包名**。
 
-### 添加测试用户
+上传需要测试的 APK 至开发者中心，等待审核通过。
 
-前往开发者中心   >>   点击<Blue>游戏服务</Blue>   >>   点击<Blue>生态服务</Blue>   >>   点击<Blue>正版验证</Blue>   >>   填写测试用户的 TapTap ID 。
+#### 2.添加测试用户
 
-### 开始测试
+前往**开发者中心 > 游戏服务 > 生态服务 > 正版验证 > 游戏配置 > 测试用户管理**，填写测试用户的 TapTap ID 。
 
-在 TapTap 客户端使用已填写的测试用户账号登录。
+#### 3.售卖设置
 
-## 正式开始售卖
+在**开发者中心 > 商店 > 售卖设置**中为游戏设置测试价格，建议测试价格设置为 0.01 元，提交并等待审核通过。
 
-### 完善应用信息
+#### 4.开始测试
 
-前往开发者中心，按照[物料要求](/store/store-material/)填写应用信息，并审核通过。
+打开 TapTap 客户端，使用上面填写的测试用户账号登录，从游戏商店页面开始正版验证的测试。
 
-### 设置售卖价格
+测试用户可在 TapTap 购买这个付费游戏，购买后才能顺利下载并进入游戏。
 
-前往开发者中心 >> <Blue>售卖设置</Blue> ，开启售卖开关，设置游戏售卖金额，提交审核，并同步对接的 TapTap 运营相关信息。
+如果测试用户未购买，通过其他途径安装游戏 APK，进入游戏后会弹出不可由玩家手动取消的弹窗，显示「游戏未激活，请前往 TapTap 购买此游戏」。
 
-### 正式上线
+## 正式售卖
+
+完成上面的测试环节后，游戏可以开始售卖。按照以下步骤操作：
+
+#### 1.完善应用信息
+
+前往开发者中心，按照[物料要求](/store/store-material/)填写应用信息，等待审核通过。
+
+#### 2.设置售卖价格
+
+前往**开发者中心 > 商店 > 售卖设置**，开启售卖开关，设置游戏正常售卖金额，提交审核，并同步对接的 TapTap 运营相关信息。
+
+#### 3.正式上线
 
 所有流程都确保顺利后，游戏可<Conditional region='cn'>[正式上线](/store/store-release/)</Conditional><Conditional region='global'>[正式上线](/store/store-publish-game)</Conditional>.
 
----
-
 ## 常见问题
 
-### 关于 Android 11 无法拉起 TapTap 客户端的解决方案
+### Android 11 无法拉起 TapTap 客户端
 
-Android 11 加强了隐私保护策略，引入了大量变更和限制，其中一个重要变更 — [软件包可见性](https://developer.android.com/about/versions/11/privacy/package-visibility) ，将会导致第三方应用无法拉起 TapTap 客户端，从而影响 TapTap 相关功能的正常使用 ，包括但不限于更新唤起 TapTap 、购买验证等功能。
+Android 11 加强了隐私保护策略，引入了大量变更和限制，其中一个重要变更——[软件包可见性](https://developer.android.com/about/versions/11/privacy/package-visibility) ，将会导致第三方应用无法拉起 TapTap 客户端，从而影响 TapTap 相关功能的正常使用 ，包括但不限于更新唤起 TapTap 、购买验证等功能。
 特别需要注意的是，Android 11 的该变更只会影响到升级 ` targetSdkVersion=30 ` 的应用，未升级的应用暂不受影响。
 
 **方案一：**
 
-编译时将 ` targetSdkVersion` 改为 29（目前设置成 30 会触发该问题）
+编译时将 `targetSdkVersion` 改为 29（目前设置成 30 会触发该问题）。
 
 **方案二：**
 
-1. 将 gradle build tools 改为 4.1.0+
+1. 将 gradle build tools 改为 4.1.0+：
 
     ```java
     classpath 'com.android.tools.build:gradle:4.1.0'
     ```
 
-2. 在 AndroidManifest.xml 里添加如下内容
+2. 在 AndroidManifest.xml 里添加如下内容：
 
     ```xml
     <queries>


### PR DESCRIPTION
根据内部文档+问人，改了文档：

- SDK 获取，增加 Android 部分（之前只有 Unity）
- 目前「测试」一节，写得过于简单，大部分正版验证工单都是因为游戏测试时无法确定正常的流程是什么。改得比较多。而且这是一个有顺序的流程，加了序号，降级为四级标题，避免右边栏排版不好看。
- 另外就是一些措辞和标点符号。