### PR TITLE
fix(login): minor improvements

### DIFF
--- a/docs/sdk/start/quickstart.mdx
+++ b/docs/sdk/start/quickstart.mdx
@@ -341,9 +341,9 @@ TapBootstrap.Init(config);
 ```java
 TapConfig tdsConfig = new TapConfig.Builder()
         .withAppContext(MainActivity.this) // Context 上下文
-        .withClientId("your_client_id") // 开发者中心对应 Client ID
-        .withClientToken("your_client_token") // 开发者中心对应 Client Token
-        .withServerUrl("https://your_server_url") // 开发者中心 > 你的游戏 > 游戏服务 > 基本信息 > 域名配置 > API
+        .withClientId("your_client_id") // 必须，开发者中心对应 Client ID
+        .withClientToken("your_client_token") // 必须，开发者中心对应 Client Token
+        .withServerUrl("https://your_server_url") // 必须，开发者中心 > 你的游戏 > 游戏服务 > 基本信息 > 域名配置 > API
         .withRegionType(TapRegionType.CN) // TapRegionType.CN：中国大陆，TapRegionType.IO：其他国家或地区
         .build();
 TapBootstrap.init(MainActivity.this, tdsConfig);
@@ -352,18 +352,20 @@ TapBootstrap.init(MainActivity.this, tdsConfig);
 ```objectivec
 // 开发者必须至少依赖 `TapBootstrap`、`TapLogin`、`TapCommon` 以及 `LeanCloudObjc` 模块，并按照如下方式完成初始化：
 TapConfig *config = [TapConfig new];
-config.clientId = @"your_client_id"; // 开发者中心对应 Client ID
-config.clientToken = @"your_client_token"; // 开发者中心对应 Client Token
+config.clientId = @"your_client_id"; // 必须，开发者中心对应 Client ID
+config.clientToken = @"your_client_token"; // 必须，开发者中心对应 Client Token
+config.serverURL = @"https://your_server_url"; // 必须，开发者中心 > 你的游戏 > 游戏服务 > 基本信息 > 域名配置 > API
 config.region = TapSDKRegionTypeCN; // TapSDKRegionTypeCN：中国大陆，TapSDKRegionTypeIO：其他国家或地区
-config.serverURL = @"https://your_server_url"; // 开发者中心 > 你的游戏 > 游戏服务 > 基本信息 > 域名配置 > API
 [TapBootstrap initWithConfig:config];
 ```
 
 </MultiLang>
 
-`client_id`、`client_token` 信息可在 **开发者中心 > 你的游戏 > 游戏服务 > 应用配置** 查看。
+初始化的时候，**必须填入** `client_id`、`client_token` 和 `server_url`，其中：
 
-`server_url` 请**使用 HTTPS 协议**，其中的域名请参考文档关于 **[域名](/sdk/start/get-ready/#域名)** 的说明。
+* `client_id`、`client_token` 信息可在 **开发者中心 > 你的游戏 > 游戏服务 > 应用配置** 查看。
+
+* `server_url` 请**使用 HTTPS 协议**，参考文档关于 **[域名](/sdk/start/get-ready/#域名)** 的说明。
 
 ## 接入功能
 

--- a/docs/sdk/taptap-login/guide/start.mdx
+++ b/docs/sdk/taptap-login/guide/start.mdx
@@ -33,6 +33,10 @@ import Languages from '../../_partials/languages.mdx';
 
 无论使用哪种方式，首先都需要在 **开发者中心 > 游戏服务 > 功能接入** 开启「TapTap 登录」。
 
+## SDK 获取及初始化
+
+参考 [快速开始](/sdk/start/quickstart/) 创建应用、完成项目配置和 [初始化](/sdk/start/quickstart/#初始化)。
+
 ## 用 TapTap OAuth 授权结果直接登录账户系统
 
 对于「TapTap 用户登录」，TapSDK 提供了特别的支持，以帮助开发者以最便捷的方式和最少的时间完成接入。你可以直接调用 `TDSUser#loginWithTapTap` 方法来一键登录，例如：


### PR DESCRIPTION
简单改改。

- 初始化部分，仅 unity 的示例里写了哪几个是必须填写的参数，补一下 Android 和 iOS 部分，并在下方的文字里再强调一遍。看工单还是有用户认为 sever_url 不是必须的。
- 内建账户下的登录，加一下 sdk 初始化。我们预期的阅读顺序是先读 快速开始 然后再看 登录，但也有可能只想接登录的开发者直接看了这一篇，这种情况，内建账户下的 TapTap 登录就缺少了项目配置和初始化部分。