### PR TITLE
SDK 下载渠道添加国内镜像下载

### DIFF
--- a/docs/tap-download.mdx
+++ b/docs/tap-download.mdx
@@ -9,7 +9,7 @@ title: 资源下载
 - [TapSDK iOS](https://github.com/taptap/TapSDK-iOS/releases)
 - [LeanCloud C# SDK](https://github.com/leancloud/csharp-sdk/releases)
 
-考虑部分开发者 GitHub 网站服务器无法快速加载 SDK 的问题，因此提供国内网络环境 SDK 镜像下载：
+若无法顺利通过上述链接获取 SDK，可尝试换用以下镜像：
 
 - [TapSDK Unity](https://releases.leanapp.cn/#/taptap/TapSDK-Unity/releases)
 - [TapSDK Android](https://releases.leanapp.cn/#/taptap/TapSDK-Android/releases)

--- a/docs/tap-download.mdx
+++ b/docs/tap-download.mdx
@@ -9,6 +9,13 @@ title: 资源下载
 - [TapSDK iOS](https://github.com/taptap/TapSDK-iOS/releases)
 - [LeanCloud C# SDK](https://github.com/leancloud/csharp-sdk/releases)
 
+考虑部分开发者 GitHub 网站服务器无法快速加载 SDK 的问题，因此提供国内网络环境 SDK 镜像下载：
+
+- [TapSDK Unity](https://releases.leanapp.cn/#/taptap/TapSDK-Unity/releases)
+- [TapSDK Android](https://releases.leanapp.cn/#/taptap/TapSDK-Android/releases)
+- [TapSDK iOS](https://releases.leanapp.cn/#/taptap/TapSDK-iOS/releases)
+- [LeanCloud C# SDK](https://releases.leanapp.cn/#/leancloud/csharp-sdk/releases)
+
 ## TapSDKSuite 悬浮窗
 
 - [Unity](https://github.com/taptap/TapSDKSuite-Unity)


### PR DESCRIPTION
考虑部分开发者 GitHub 网站服务器无法快速加载 SDK 的问题，因此提供国内网络环境 SDK 镜像下载：