### PR TITLE
fix(friends): landing page configuration

### DIFF
--- a/docs/sdk/friends/follow.mdx
+++ b/docs/sdk/friends/follow.mdx
@@ -852,7 +852,7 @@ callback:^(TDSFriendResult * _Nullable result, NSError * _Nullable error) {
 如果计划部署在云引擎上，需注意云引擎的免费实例会自动休眠，请购买标准实例使用。
 
 我们提供了[开源的落地页示例项目][repo]，修改相应配置后可直接构建、部署、使用。
-注意，示例项目中的 `VITE_ANDROID_LINK` 环境变量格式为 `scheme://host/path`。
+注意，示例项目中的 `GAME_ANDROID_LINK` 环境变量格式为 `scheme://host/path`。
 `host` 和 `path` 的值需和 Android 的 `AndroidManifest.xml` 中的值保持一致。
 
 [repo]: https://github.com/taptap/TapFriends-landing-page
@@ -883,7 +883,7 @@ callback:^(TDSFriendResult * _Nullable result, NSError * _Nullable error) {
 </activity>
 ```
 
-那么落地页项目中 `VITE_ANDROID_LINK` 的值为 `tapsdk://游戏应用ID/friends`。
+那么落地页项目中 `GAME_ANDROID_LINK` 的值为 `tapsdk://游戏应用ID/friends`。
 
 落地页网站的地址需要在客户端配置：
 

--- a/docs/sdk/friends/mutual.mdx
+++ b/docs/sdk/friends/mutual.mdx
@@ -1171,7 +1171,7 @@ TDSFriends.checkFriendship("5b0b97cf06f4fd0abc0abe35", new Callback<Boolean>() {
 如果计划部署在云引擎上，需注意云引擎的免费实例会自动休眠，请购买标准实例使用。
 
 我们提供了[开源的落地页示例项目][repo]，修改相应配置后可直接构建、部署、使用。
-注意，示例项目中的 `VITE_ANDROID_LINK` 环境变量格式为 `scheme://host/path`。
+注意，示例项目中的 `GAME_ANDROID_LINK` 环境变量格式为 `scheme://host/path`。
 `host` 和 `path` 的值需和 Android 的 `AndroidManifest.xml` 中的值保持一致。
 
 [repo]: https://github.com/taptap/TapFriends-landing-page
@@ -1202,7 +1202,7 @@ TDSFriends.checkFriendship("5b0b97cf06f4fd0abc0abe35", new Callback<Boolean>() {
 </activity>
 ```
 
-那么落地页项目中 `VITE_ANDROID_LINK` 的值为 `tapsdk://游戏应用ID/friends`。
+那么落地页项目中 `GAME_ANDROID_LINK` 的值为 `tapsdk://游戏应用ID/friends`。
 
 落地页网站的地址需要在客户端配置：
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/sdk/friends/follow.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/sdk/friends/follow.mdx
@@ -852,7 +852,7 @@ The landing page can be deployed on [Cloud Engine](/sdk/engine/overview/) or any
 If you plan to use Cloud Engine, keep in mind that the free instances provided by Cloud Engine come with auto-hibernation. Please consider purchasing standard instances.
 
 We provide an [open-source demo landing page] for you to use. You can build, deploy, and use it with your own configurations.
-Notice that the format of the `VITE_ANDROID_LINK` environment variable of the demo is `scheme://host/path`.
+Notice that the format of the `GAME_ANDROID_LINK` environment variable of the demo is `scheme://host/path`.
 The values of `host` and `path` should be consistent with those written in the `AndroidManifest.xml` of your Android project.
 
 [repo]: https://github.com/taptap/TapFriends-landing-page
@@ -883,7 +883,7 @@ For example, if the `AndroidManifest.xml` of your project contains the following
 </activity>
 ```
 
-The value of `VITE_ANDROID_LINK` in your landing page should be `tapsdk://APP_ID/friends`.
+The value of `GAME_ANDROID_LINK` in your landing page should be `tapsdk://APP_ID/friends`.
 
 The address of the landing page should be configured in the client:
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/sdk/friends/mutual.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/sdk/friends/mutual.mdx
@@ -1171,7 +1171,7 @@ The landing page can be deployed on [Cloud Engine](/sdk/engine/overview/) or any
 If you plan to use Cloud Engine, keep in mind that the free instances provided by Cloud Engine come with auto-hibernation. Please consider purchasing standard instances.
 
 We provide an [open-source demo landing page] for you to use. You can build, deploy, and use it with your own configurations.
-Notice that the format of the `VITE_ANDROID_LINK` environment variable of the demo is `scheme://host/path`.
+Notice that the format of the `GAME_ANDROID_LINK` environment variable of the demo is `scheme://host/path`.
 The values of `host` and `path` should be consistent with those written in the `AndroidManifest.xml` of your Android project.
 
 [repo]: https://github.com/taptap/TapFriends-landing-page
@@ -1202,7 +1202,7 @@ For example, if the `AndroidManifest.xml` of your project contains the following
 </activity>
 ```
 
-The value of `VITE_ANDROID_LINK` in your landing page should be `tapsdk://APP_ID/friends`.
+The value of `GAME_ANDROID_LINK` in your landing page should be `tapsdk://APP_ID/friends`.
 
 The address of the landing page should be configured in the client:
 


### PR DESCRIPTION
### 前因

[好友落地页](https://github.com/taptap/TapFriends-landing-page) 的早期版本用的是 vite 自带的注入环境变量的功能，其默认前缀是 `VITE_`。

后续增加了从 .env 文件中读取配置的功能，同时更换了实现方式，前缀也改为 `GAME_` 了。
