### PR TITLE
chore: show tapsdk-tap-antiaddiction-practice blog

### DIFF
--- a/docs/sdk/anti-addiction/guide.mdx
+++ b/docs/sdk/anti-addiction/guide.mdx
@@ -12,9 +12,9 @@ import sdkVersions from '/src/docComponents/sdkVersions';
 使用 TDS 实名认证和防沉迷服务之前，需要在**开发者中心后台 > 游戏服务 > 生态服务 > 合规认证** 处开通服务，可选择「已有版号」或「暂无版号」方案。
 :::
 
-<!--
+:::info
 推荐阅读博客：[实名认证和防沉迷功能接入](https://blog.taptap.dev/posts/tapsdk-tap-antiaddiction-practice)，加深对实名认证和防沉迷功能的理解。
--->
+:::
 
 ## SDK 配置
 


### PR DESCRIPTION
之前藏起来是因为博客没更新。现在可以放出来给开发者参考用了