### PR TITLE
fix(lc): init js realtime sdk with typed message

### DIFF
--- a/docs/sdk/storage/js-guide/setup-js.mdx
+++ b/docs/sdk/storage/js-guide/setup-js.mdx
@@ -389,19 +389,15 @@ setAdapters(adapters);
 ```js
 // 需要保证依次加载三个文件
 const AV = require("./libs/leancloud-storage.js");
-const {
-  Realtime,
-  TextMessage,
-  setAdapters,
-} = require("./libs/leancloud-realtime.js");
-const {
-  TypedMessagesPlugin,
-  ImageMessage,
-} = require("./libs/typed-messages.min.js");
+const IM = require("./libs/leancloud-realtime.js");
+const initPlugin = require("./libs/typed-messages.min.js");
 const adapters = require("./libs/leancloud-adapters-weapp.js");
 
+const { Realtime, TextMessage } = IM;
+const { TypedMessagesPlugin, ImageMessage } = initPlugin(AV, IM);
+
 AV.setAdapters(adapters); // 为存储 SDK 设置 adapters
-setAdapters(adapters); // 为即时通讯 SDK 设置 adapters
+IM.setAdapters(adapters); // 为即时通讯 SDK 设置 adapters
 ```
 
 </TabItem>
@@ -513,11 +509,11 @@ const IM = require("leancloud-realtime/im");
 const initPlugin = require("leancloud-realtime-plugin-typed-messages");
 const adapters = require("@leancloud/platform-adapters-alipay");
 
-const { Realtime, setAdapters } = IM;
+const { Realtime, TextMessage } = IM;
 const { TypedMessagesPlugin, ImageMessage } = initPlugin(AV, IM);
 
 AV.setAdapters(adapters); // 为存储 SDK 设置 adapters
-setAdapters(adapters); // 为即时通讯 SDK 设置 adapters
+IM.setAdapters(adapters); // 为即时通讯 SDK 设置 adapters
 ```
 
 </TabItem>
@@ -601,11 +597,11 @@ const IM = require("leancloud-realtime/im");
 const initPlugin = require("leancloud-realtime-plugin-typed-messages");
 const adapters = require("@leancloud/platform-adapters-baidu");
 
-const { Realtime, setAdapters } = IM;
+const { Realtime, TextMessage } = IM;
 const { TypedMessagesPlugin, ImageMessage } = initPlugin(AV, IM);
 
 AV.setAdapters(adapters); // 为存储 SDK 设置 adapters
-setAdapters(adapters); // 为即时通讯 SDK 设置 adapters
+IM.setAdapters(adapters); // 为即时通讯 SDK 设置 adapters
 ```
 
 </TabItem>
@@ -686,19 +682,15 @@ setAdapters(adapters);
 ```js
 // 需要保证依次加载三个文件
 const AV = require("./libs/leancloud-storage.js");
-const {
-  Realtime,
-  TextMessage,
-  setAdapters,
-} = require("./libs/leancloud-realtime.js");
-const {
-  TypedMessagesPlugin,
-  ImageMessage,
-} = require("./libs/typed-messages.min.js");
+const IM = require("./libs/leancloud-realtime.js");
+const initPlugin = require("./libs/typed-messages.min.js");
 const adapters = require("./libs/leancloud-adapters-toutiao.js");
 
+const { Realtime, TextMessage } = IM;
+const { TypedMessagesPlugin, ImageMessage } = initPlugin(AV, IM);
+
 AV.setAdapters(adapters); // 为存储 SDK 设置 adapters
-setAdapters(adapters); // 为即时通讯 SDK 设置 adapters
+IM.setAdapters(adapters); // 为即时通讯 SDK 设置 adapters
 ```
 
 </TabItem>
@@ -845,12 +837,12 @@ const AV = require("leancloud-storage/core");
 const IM = require("leancloud-realtime/im");
 const initPlugin = require("leancloud-realtime-plugin-typed-messages");
 
-const { Realtime, setAdapters } = IM;
+const { Realtime, TextMessage } = IM;
 const { TypedMessagesPlugin, ImageMessage } = initPlugin(AV, IM);
 
 const adapters = require("@leancloud/platform-adapters-quickapp");
 AV.setAdapters(adapters);
-setAdapters(adapters);
+IM.setAdapters(adapters);
 ```
 
 </TabItem>
@@ -955,11 +947,11 @@ import IM from "leancloud-realtime/im";
 import initPlugin from "leancloud-realtime-plugin-typed-messages";
 import * as adapters from "@leancloud/platform-adapters-react-native";
 
-const { Realtime, setAdapters } = IM;
+const { Realtime, TextMessage } = IM;
 const { TypedMessagesPlugin, ImageMessage } = initPlugin(AV, IM);
 
 AV.setAdapters(adapters);
-setAdapters(adapters);
+IM.setAdapters(adapters);
 ```
 
 </TabItem>
@@ -1086,14 +1078,15 @@ setAdapters(adapters);
 
 ```js
 const AV = require("leancloud-storage/core");
-const { Realtime, setAdapters } = require("leancloud-realtime/im");
-const {
-  TypedMessagesPlugin,
-  ImageMessage,
-} = require("leancloud-realtime-plugin-typed-messages");
+const IM = require("leancloud-realtime/im");
+const initPlugin = require("leancloud-realtime-plugin-typed-messages");
 const adapters = require("platform-adapters-xyz");
+
+const { Realtime, TextMessage } = IM;
+const { TypedMessagesPlugin, ImageMessage } = initPlugin(AV, IM);
+
 AV.setAdapters(adapters);
-setAdapters(adapters);
+IM.setAdapters(adapters);
 ```
 
 </TabItem>


### PR DESCRIPTION
JS 即时通讯 SDK 的富媒体消息插件之前改过，初始化方式变成 `initPlugin(AV, IM)` 了。没想到落下了一部分没改，这里给改过来。