### PR TITLE
docs: add faq

### DIFF
--- a/docs/sdk/start/faq.mdx
+++ b/docs/sdk/start/faq.mdx
@@ -102,6 +102,9 @@ TapSDK 现在自动包含了 LeanCloud 核心 SDK，LeanCloud SDK 依赖如下�
 
 ## TapTap 登录
 
+## TapTap For iOS 登录报 `accessToken: sdk_not_matched` 异常
+检查 TapTap 开发者后台的应用是否配置了应用的 Bundle ID。
+
 ### TapTap 登录报 `signature not match` 异常
 接入了 TapTap 登录但没有在开发者中心后台配置签名或者配置错了都会提示该异常。有的开发者可能没有调试出异常信息，可以通过这种方式进行验证：如果将 TapTap 客户端卸载，测试登录功能时会弹出 WebView 授权，而测试设备安装了 TapTap 客户端则无法拉起客户端授权，这种情况基本上就是因为签名配置问题导致的，请参考[文档](/sdk/start/quickstart/#配置签名证书)完成配置。
 


### PR DESCRIPTION
- 增加 iOS TapTap 登录报 accessToken: sdk_not_matched 异常的解决方案。