### PR TITLE
docs: Remove outdated TapSDKSuite

### DIFF
--- a/docs/tap-download.mdx
+++ b/docs/tap-download.mdx
@@ -19,12 +19,6 @@ title: 资源下载
 - [TapSDK iOS](https://releases.leanapp.cn/#/taptap/TapSDK-iOS/releases)
 - [LeanCloud C# SDK](https://releases.leanapp.cn/#/leancloud/csharp-sdk/releases)
 
-## TapSDKSuite 悬浮窗
-
-- [Unity](https://github.com/taptap/TapSDKSuite-Unity)
-- [Android](https://github.com/taptap/TapSDKSuite-Android)
-- [iOS](https://github.com/taptap/TapSDKSuite-iOS)
-
 ## Demos
 
 - [Unity](https://github.com/taptap/TapSDK-Unity-Demo/tree/master)      【[Unity 安装包下载](https://capacity-files.lcfile.com/1GppPQSObLW6G5a40dVJNv5vRwqal6h9/Tds_demo.apk)】

--- a/i18n/en/docusaurus-plugin-content-docs/current/tap-download.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/tap-download.mdx
@@ -9,12 +9,6 @@ title: Downloads
 - [TapSDK iOS](https://github.com/taptap/TapSDK-iOS/releases)
 - [LeanCloud C# SDK](https://github.com/leancloud/csharp-sdk/releases)
 
-## TapSDKSuite
-
-- [Unity](https://github.com/taptap/TapSDKSuite-Unity)
-- [Android](https://github.com/taptap/TapSDKSuite-Android)
-- [iOS](https://github.com/taptap/TapSDKSuite-iOS)
-
 ## Demos
 
 - [Unity](https://github.com/taptap/TapSDK-Unity-Demo)


### PR DESCRIPTION
- 去除过时的 TapSDKSuite 悬浮窗下载。