### PR TITLE
ue 添加多语言类型

### DIFF
--- a/docs/sdk/_partials/languages.mdx
+++ b/docs/sdk/_partials/languages.mdx
@@ -107,15 +107,15 @@ TapUECommon::SetLanguage(ELanguageType::AUTO);
 UENUM(BlueprintType)
 enum class ELanguageType : uint8
 {
-	AUTO = 0,   // 自动
-	ZH,			// 简体中文
-	EN,			// 英文，海外默认语言
-	ZHTW,		// 繁体中文
-	JA,			// 日语
-	KO,			// 韩语
-	TH,			// 泰文
-	ID,			// 印尼文
-	DE, 		// 德语
+    AUTO = 0,   // 自动
+    ZH,			// 简体中文
+    EN,			// 英文，海外默认语言
+    ZHTW,		// 繁体中文
+    JA,			// 日语
+    KO,			// 韩语
+    TH,			// 泰文
+    ID,			// 印尼文
+    DE, 		// 德语
     ES, 		// 西班牙语
     FR, 		// 法语
     PT, 		// 葡萄牙语

--- a/docs/sdk/_partials/languages.mdx
+++ b/docs/sdk/_partials/languages.mdx
@@ -115,6 +115,13 @@ enum class ELanguageType : uint8
 	KO,			// 韩语
 	TH,			// 泰文
 	ID,			// 印尼文
+	DE, 		// 德语
+    ES, 		// 西班牙语
+    FR, 		// 法语
+    PT, 		// 葡萄牙语
+    RU, 		// 俄语
+    TR, 		// 土耳其语
+    VI, 		// 越南语
 };
 ```
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/sdk/_partials/languages.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/sdk/_partials/languages.mdx
@@ -94,6 +94,13 @@ enum class ELanguageType : uint8
 	KO,			// Korean
 	TH,			// Thai
 	ID,			// Indonesian
+	DE,         // German
+    ES,         // spanish
+    FR,         // French
+    PT,         // Portuguese
+    RU,         // Russian
+    TR,         // turkish
+    VI,         // Vietnamese
 };
 ```
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/sdk/_partials/languages.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/sdk/_partials/languages.mdx
@@ -86,15 +86,15 @@ The following languages are supported:
 UENUM(BlueprintType)
 enum class ELanguageType : uint8
 {
-	AUTO = 0,   // Auto
-	ZH,			// Simplified Chinese
-	EN,			// English
-	ZHTW,		// Traditional Chinese
-	JA,			// Japanese
-	KO,			// Korean
-	TH,			// Thai
-	ID,			// Indonesian
-	DE,         // German
+    AUTO = 0,   // Auto
+    ZH,			// Simplified Chinese
+    EN,			// English
+    ZHTW,		// Traditional Chinese
+    JA,			// Japanese
+    KO,			// Korean
+    TH,			// Thai
+    ID,			// Indonesian
+    DE,         // German
     ES,         // spanish
     FR,         // French
     PT,         // Portuguese

--- a/i18n/en/docusaurus-plugin-content-docs/current/sdk/_partials/languages.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/sdk/_partials/languages.mdx
@@ -87,19 +87,19 @@ UENUM(BlueprintType)
 enum class ELanguageType : uint8
 {
     AUTO = 0,   // Auto
-    ZH,			// Simplified Chinese
-    EN,			// English
-    ZHTW,		// Traditional Chinese
-    JA,			// Japanese
-    KO,			// Korean
-    TH,			// Thai
-    ID,			// Indonesian
+    ZH,         // Simplified Chinese
+    EN,         // English
+    ZHTW,       // Traditional Chinese
+    JA,         // Japanese
+    KO,         // Korean
+    TH,         // Thai
+    ID,         // Indonesian
     DE,         // German
     ES,         // spanish
     FR,         // French
     PT,         // Portuguese
     RU,         // Russian
-    TR,         // turkish
+    TR,         // Turkish
     VI,         // Vietnamese
 };
 ```


### PR DESCRIPTION
ue 添加多语言类型：
- 德语
- 西班牙语
- 法语
- 葡萄牙语
- 俄语
- 土耳其语
- 越南语