### PR TITLE
docs: change the preference of the fields "access_token" and "kid" 

### DIFF
--- a/docs/sdk/taptap-login/guide/taptap-oauth.mdx
+++ b/docs/sdk/taptap-login/guide/taptap-oauth.mdx
@@ -36,7 +36,7 @@ Mac Token 生成算法见文档中的 [MAC Token 算法](#mac-token-算法) 部�
 2. 再把移动端获取的参数发到游戏服务器，服务端签算 mac token。
 3. 请求 <Conditional region='cn'>`https://open.tapapis.cn/account/profile/v1`</Conditional><Conditional region='global'>`https://openapi.tap.io/account/profile/v1`</Conditional> ， header 携带 `mac token`。
 
-注意：当前实际返回的 `kid` 和 `access_token` 值相等，建议使用 `access_token`。
+注意：当前实际返回的 `kid` 和 `access_token` 值相等，建议使用 `kid`。
 
 ## API
 当 SDK 只请求 basic_info 的权限时，请使用基础信息接口，请求 public_profile 时，请使用详细信息接口。

--- a/i18n/en/docusaurus-plugin-content-docs/current/sdk/taptap-login/guide/taptap-oauth.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/sdk/taptap-login/guide/taptap-oauth.mdx
@@ -37,7 +37,7 @@ The following interface is an example for domestic applications. However, when t
 2. Send the parameters obtained from the mobile client to the game server, then the server will sign a MAC Token.
 3. Request <Conditional region='cn'>`https://open.tapapis.cn/account/profile/v1`</Conditional><Conditional region='global'>`https://openapi.tap.io/account/profile/v1`</Conditional> with `mac token` included in the header.
 
-Note: The returned `kid` and `access_token` values are equal. We recommend using `access_token`.
+Note: The returned `kid` and `access_token` values are equal. We recommend using `kid`.
 
 ## API
 


### PR DESCRIPTION
https://xindong.slack.com/archives/C01S9A1B4GK/p1698895159125479
这两个字段目前用户中心是等效的，短期内也没有计划用谁取代谁, 先改为一样的
