### PR TITLE
feat(nodejs): add docs for cloud engine corepack support

### DIFF
--- a/docs/sdk/engine/_partials/nodejs-setup-dependencies.mdx
+++ b/docs/sdk/engine/_partials/nodejs-setup-dependencies.mdx
@@ -14,12 +14,8 @@
 
 在安装依赖的过程中，云引擎会正常触发 NPM 的生命周期脚本（[Life Cycle Scripts](https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts)），如 `postinstall`、`prepare` 等。
 
-:::note
-如果存在 `package-lock.json`，云引擎会优先使用 `npm ci` 安装依赖（需要 Node.js 10 以上）。否则云引擎会使用 `npm install --production` 安装依赖（这意味着 `devDependencies` 中的依赖不会被安装）。
-:::
-
-:::note
-如果存在 `yarn.lock`，云引擎会优先使用 `yarn` 安装依赖（需要 Node.js 4.8 以上）。如果不希望在云端使用 Yarn，请将它们加入 `.gitignore`（Git 部署时）或 `.leanignore`（命令行工具部署时）。请注意 `yarn.lock` 中包含了下载依赖的 URL，请选择合适的源，否则可能会增加构建时间。
-:::
-
 因为云引擎会在云端安装依赖，所以命令行工具默认也不会上传 `node_modules` 目录；如果使用 Git 部署，也建议将 `node_modules` 目录添加到 `.gitignore` 中，使其不加入版本控制。
+
+:::note
+云引擎会上传 `.yarn` 文件夹，所以如果启用了 Yarn 2+ 的 [PnP（Plug'n'Play）](https://yarnpkg.com/features/pnp)但不想使用 [Zero-installs](https://yarnpkg.com/features/caching#zero-installs)，请将 `.yarn/cache` 加入到 `.gitignore` 和 `.leanignore` 中
+:::

--- a/docs/sdk/engine/_partials/nodejs-setup-package-mamager.mdx
+++ b/docs/sdk/engine/_partials/nodejs-setup-package-mamager.mdx
@@ -1,0 +1,57 @@
+云引擎目前支持以下包管理器：
+
+- [`npm`](https://docs.npmjs.com/cli/v10/commands/npm)
+- [`pnpm`](https://pnpm.io)
+- [`Yarn 1`](https://classic.yarnpkg.com)
+- [`Yarn 2+`](https://yarnpkg.com)
+
+云引擎会按照以下条件使用包管理器：
+
+| 包管理器 | 条件                                | 版本                        |
+| -------- | ----------------------------------- | --------------------------- |
+| pnpm     | 存在合法能被解析的 `pnpm-lock.yaml` |                             |
+|          | `lockfileVersion: '6.0'` 或更高     | 8                           |
+|          | `lockfileVersion: 5.3` 或更高       | 7                           |
+|          | 其他                                | 6                           |
+| Yarn 1   | 存在 `yarn.lock`                    | 1                           |
+| Yarn 2+  | 不默认支持，需通过 `Corepack` 启用  | 2+                          |
+| npm      | 其他情况                            | 使用 Node.js 默认提供的 npm |
+
+### 实验性 Corepack 支持
+
+**由于 Corepack 还是实验性特性，云引擎不能保证对 Corepack 的支持是稳定的**
+
+通过给分组设置 `ENABLE_EXPERIMENTAL_COREPACK` 环境变量为任意非空字符串来启用实验性 Corepack 支持。
+
+云引擎会通过调用 Corepack 读取 `package.json` 里的 `packageManager` 字段来自动识别、使用用户指定的包管理器，这也是目前唯一一种使用 Yarn 2+ 的方式。
+
+假设有以下 `package.json`：
+
+```json title="package.json"
+{
+  "name": "example",
+  "packageManager": "yarn@4.0.2"
+}
+```
+
+此时云引擎会自动调用 `corepack prepare --activate` 并识别包管理器为 Yarn 2+。
+
+参考：[Corepack](https://nodejs.org/api/corepack.html)
+
+### 默认命令
+
+云引擎默认运行的脚本会随着包管理器的变化而变化，如使用了 pnpm， `npm ci` 会变成 `pnpm install --frozen-lockfile`。
+
+云引擎只有在没有指定 `installDevDependencies` 为 `true` 且构建脚本为空（没有手动指定，`package.json` 里的 `scripts.build` 不存在）时才会省略 devDependencies 的安装。
+
+| 阶段    | 包管理器 | 条件                                                               | 命令                                                                        |
+| ------- | -------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| install | npm      | Node.js 10 以上且存在 `package-lock.json` 或 `npm-shrinkwrap.json` | `npm ci`                                                                    |
+|         |          |                                                                    | `npm install` 或 `npm install --omit=dev`                                   |
+|         | pnpm     |                                                                    | `pnpm install --frozen-lockfile` 或 `pnpm install --frozen-lockfile --prod` |
+|         | Yarn 1   |                                                                    | `yarn install` 或 `yarn install --production`                               |
+|         | Yarn 2+  |                                                                    | `yarn install`                                                              |
+
+:::note
+请注意 Yarn 1 只会使用 `yarn.lock` 内解析的 URL 下载依赖且不会遵循用户设置的源，请选择合适的源，否则可能会增加构建时间。
+:::

--- a/docs/sdk/engine/_partials/nodejs-setup-package-mamager.mdx
+++ b/docs/sdk/engine/_partials/nodejs-setup-package-mamager.mdx
@@ -1,21 +1,21 @@
 云引擎目前支持以下包管理器：
 
-- [`npm`](https://docs.npmjs.com/cli/v10/commands/npm)
-- [`pnpm`](https://pnpm.io)
-- [`Yarn 1`](https://classic.yarnpkg.com)
-- [`Yarn 2+`](https://yarnpkg.com)
+- [npm](https://docs.npmjs.com/cli/v10/commands/npm)
+- [pnpm](https://pnpm.io)
+- [Yarn 1](https://classic.yarnpkg.com)
+- [Yarn 2+](https://yarnpkg.com)
 
 云引擎会按照以下条件使用包管理器：
 
-| 包管理器 | 条件                                | 版本                        |
-| -------- | ----------------------------------- | --------------------------- |
-| pnpm     | 存在合法能被解析的 `pnpm-lock.yaml` |                             |
-|          | `lockfileVersion: '6.0'` 或更高     | 8                           |
-|          | `lockfileVersion: 5.3` 或更高       | 7                           |
-|          | 其他                                | 6                           |
-| Yarn 1   | 存在 `yarn.lock`                    | 1                           |
-| Yarn 2+  | 不默认支持，需通过 `Corepack` 启用  | 2+                          |
-| npm      | 其他情况                            | 使用 Node.js 默认提供的 npm |
+| 包管理器 | 条件                                                      | 版本                        |
+| -------- | --------------------------------------------------------- | --------------------------- |
+| pnpm     | 存在合法能被解析的 `pnpm-lock.yaml`                       |                             |
+|          | `lockfileVersion: '6.0'` 或更高                           | 8                           |
+|          | `lockfileVersion: 5.3` 或更高                             | 7                           |
+|          | 其他                                                      | 6                           |
+| Yarn 1   | 存在 `yarn.lock`                                          | 1                           |
+| Yarn 2+  | 不默认支持，需通过 [Corepack](#实验性-corepack-支持) 启用 | 2+                          |
+| npm      | 其他情况                                                  | 使用 Node.js 默认提供的 npm |
 
 ### 实验性 Corepack 支持
 

--- a/docs/sdk/engine/deploy/nodejs.mdx
+++ b/docs/sdk/engine/deploy/nodejs.mdx
@@ -84,8 +84,8 @@ import CloudHealthCheck from "../_partials/cloud-health-check.mdx";
 install:
   - use: default
   - require:
-      - ./frontend/package.json
-      - ./frontend/package-lock.json
+    - ./frontend/package.json
+    - ./frontend/package-lock.json
   - cd frontend && npm ci
 build:
   - npm run build

--- a/docs/sdk/engine/deploy/nodejs.mdx
+++ b/docs/sdk/engine/deploy/nodejs.mdx
@@ -13,6 +13,7 @@ import CloudFilesystem from "../_partials/cloud-filesystem.mdx";
 import BuildingAdvanced from "../_partials/building-advanced.mdx";
 import BuildingBuildLogs from "../_partials/building-build-logs.mdx";
 import NodejsSetupRuntime from "../_partials/nodejs-setup-runtime.mdx";
+import NodejsSetupPackageManager from "../_partials/nodejs-setup-package-mamager.mdx";
 import NodejsSetupDependencies from "../_partials/nodejs-setup-dependencies.mdx";
 import CloudCustomDomain from "../_partials/cloud-custom-domain.mdx";
 import CloudHealthCheck from "../_partials/cloud-health-check.mdx";
@@ -21,7 +22,7 @@ import CloudHealthCheck from "../_partials/cloud-health-check.mdx";
 这篇文档是针对 Node.js 运行环境的深入介绍，如希望快速地开始使用云引擎，请查看 [快速开始部署云引擎应用](/sdk/engine/deploy/getting-started)。
 :::
 
-所有 Node.js 项目都必须在根目录包含一个 [package.json](https://docs.npmjs.com/cli/v8/configuring-npm/package-json) 才会被云引擎正确识别，云引擎也会从中读取项目对于环境的需求：
+所有 Node.js 项目都必须在根目录包含一个 [package.json](https://docs.npmjs.com/cli/v8/configuring-npm/package-json) 和启动脚本（如没有在控制台或 `leanengine.yaml` 内指定，请确保 `package.json` 内的 `scripts.start` 存在）才会被云引擎正确识别，云引擎也会从中读取项目对于环境的需求：
 
 ```json title='package.json'
 {
@@ -65,6 +66,10 @@ import CloudHealthCheck from "../_partials/cloud-health-check.mdx";
 
 <NodejsSetupRuntime />
 
+## 配置包管理器
+
+<NodejsSetupPackageManager />
+
 ## 安装依赖（`package.json`）
 
 <NodejsSetupDependencies />
@@ -79,8 +84,8 @@ import CloudHealthCheck from "../_partials/cloud-health-check.mdx";
 install:
   - use: default
   - require:
-    - ./frontend/package.json
-    - ./frontend/package-lock.json
+      - ./frontend/package.json
+      - ./frontend/package-lock.json
   - cd frontend && npm ci
 build:
   - npm run build
@@ -134,7 +139,7 @@ build:
 ### Node.js 项目的 `devDependencies` 没有安装？
 
 云引擎会在部署时用 `npm ci` 为你安装项目依赖，包括 `devDependencies`。
-不过，如果项目的 Node.js 版本小于 10，则会使用 `npm install --production` 安装依赖，相应地，`devDependencies` 中列出的依赖**不会**安装。
+不过，如果项目的 Node.js 版本小于 10，或者项目目录下没有 lockfile，则会使用 `npm install --production` 安装依赖，相应地，`devDependencies` 中列出的依赖**不会**安装，可参考 [默认命令](/sdk/engine/deploy/nodejs/#默认命令)。
 如需安装 `devDependencies`，请在项目的 `leanengine.yaml` 中指定 `installDevDependencies: true`。
 
 ### `npm ERR! peer dep missing` 错误怎么办？

--- a/docs/sdk/engine/deploy/webapp.mdx
+++ b/docs/sdk/engine/deploy/webapp.mdx
@@ -6,6 +6,7 @@ sidebar_position: 3
 
 import CloudTimezone from "../_partials/cloud-timezone.mdx";
 import NodejsSetupRuntime from "../_partials/nodejs-setup-runtime.mdx";
+import NodejsSetupPackageManager from "../_partials/nodejs-setup-package-mamager.mdx";
 import BuildingAdvanced from "../_partials/building-advanced.mdx";
 import BuildingBuildLogs from "../_partials/building-build-logs.mdx";
 import NodejsSetupDependencies from "../_partials/nodejs-setup-dependencies.mdx";
@@ -109,6 +110,10 @@ build: npm run build
 ## 配置 Node.js 版本
 
 <NodejsSetupRuntime />
+
+## 配置包管理器
+
+<NodejsSetupPackageManager />
 
 ## 安装依赖（`package.json`）
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/sdk/engine/_partials/nodejs-setup-dependencies.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/sdk/engine/_partials/nodejs-setup-dependencies.mdx
@@ -14,12 +14,8 @@ Cloud Engine will automatically install dependencies according to the `package.j
 
 While installing dependencies, Cloud Engine will trigger the [life cycle scripts](https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts) of npm, such as `postinstall` and `prepare`.
 
-:::note
-If your project contains `package-lock.json`, Cloud Engine will install dependencies with `npm ci` (requires Node.js 10 or higher). Otherwise, Cloud Engine will install dependencies with `npm install --production`, which means that dependencies listed under `devDependencies` will not be installed.
-:::
-
-:::note
-If your project contains `yarn.lock`, Cloud Engine will install dependencies with `yarn` (requires Node.js 4.8 or higher). To use npm instead of Yarn, add `yarn.lock` into `.gitignore` (if deploying with Git) or `.leanignore` (if deploying with the CLI). Since `yarn.lock` contains the URLs for downloading dependencies, please carefully choose the registry for your project, or you may experience increased build time.
-:::
-
 Since Cloud Engine installs dependencies on the server side, the CLI won’t upload `node_modules` by default. If you’re deploying with Git, you should include `node_modules` in `.gitignore` so it won’t be tracked by Git.
+
+:::note
+CLI will upload `.yarn` directory, if you don't want to enable [Zero-installs](https://yarnpkg.com/features/caching#zero-installs) when Yarn 2+ [PnP\(Plug'n'Play\)](https://yarnpkg.com/features/pnp) is used, add `.yarn/cache` to your `.gitignore` and `.leanignore`
+:::

--- a/i18n/en/docusaurus-plugin-content-docs/current/sdk/engine/_partials/nodejs-setup-package-manager.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/sdk/engine/_partials/nodejs-setup-package-manager.mdx
@@ -1,0 +1,57 @@
+Cloud Engine now supports these package managers:
+
+- [`npm`](https://docs.npmjs.com/cli/v10/commands/npm)
+- [`pnpm`](https://pnpm.io)
+- [`Yarn 1`](https://classic.yarnpkg.com)
+- [`Yarn 2+`](https://yarnpkg.com)
+
+Cloud Engine will automatically detect the package manager based on these conditions:
+
+| Package Manager | Condition                                                                                                | Version                      |
+| --------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| pnpm            | A valid `pnpm-lock.yaml` exists                                                                          |                              |
+|                 | `lockfileVersion: '6.0'` or higher                                                                       | 8                            |
+|                 | `lockfileVersion: 5.3` or higher                                                                         | 7                            |
+|                 | Otherwise                                                                                                | 6                            |
+| Yarn 1          | `yarn.lock` exists                                                                                       | 1                            |
+| Yarn 2+         | Not supported by default, enable via [Corepack](/sdk/engine/deploy/nodejs#experimental-corepack-support) | 2+                           |
+| npm             | Otherwise                                                                                                | npm with the Node.js is used |
+
+### Experimental Corepack support
+
+**Due to Corepack is still experimental, Cloud Engine can't make sure the support for Corepack is stable, use at your own risk**
+
+To enable Corepack, setting the `ENABLE_EXPERIMENTAL_COREPACK` environment variable of the group to any non-empty string.
+
+Cloud Engine will automatically detect package manager based on `packageManager` field in `package.json`, then use Corepack to install and enable the package manager. This is the only way to use Yarn 2+ for now.
+
+Assume we have a `package.json` shown below：
+
+```json title="package.json"
+{
+  "name": "example",
+  "packageManager": "yarn@4.0.2"
+}
+```
+
+Now Cloud Engine will call `corepack prepare --activate` and detect the package manager is Yarn 2+.
+
+Reference：[Corepack](https://nodejs.org/api/corepack.html)
+
+### Default commands
+
+The default commands may vary depending on the package manager, e.g. if pnpm is used, `npm ci` will be `pnpm install --frozen-lockfile`.
+
+Cloud Engine will skip installing the devDependencies only when `installDevDependencies` is not `true` and the build script is empty (which either not specified in `leanengine.yaml` or `scripts.build` in `package.json` not exists).
+
+| Pharse  | Package Mamager | Condition                                                                                 | Command                                                                     |
+| ------- | --------------- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| install | npm             | Node.js version is higher then 10 and `package-lock.json` or `npm-shrinkwrap.json` exists | `npm ci`                                                                    |
+|         |                 |                                                                                           | `npm install` or `npm install --omit=dev`                                   |
+|         | pnpm            |                                                                                           | `pnpm install --frozen-lockfile` or `pnpm install --frozen-lockfile --prod` |
+|         | Yarn 1          |                                                                                           | `yarn install` or `yarn install --production`                               |
+|         | Yarn 2+         |                                                                                           | `yarn install`                                                              |
+
+:::note
+Be adviced, Yarn 1 will use the resolved URL in `yarn.lock` without respecting your registry configuration, use proper registry before deploy to Cloud Engine, or build time might increase.
+:::

--- a/i18n/en/docusaurus-plugin-content-docs/current/sdk/engine/_partials/nodejs-setup-package-manager.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/sdk/engine/_partials/nodejs-setup-package-manager.mdx
@@ -1,21 +1,21 @@
 Cloud Engine now supports these package managers:
 
-- [`npm`](https://docs.npmjs.com/cli/v10/commands/npm)
-- [`pnpm`](https://pnpm.io)
-- [`Yarn 1`](https://classic.yarnpkg.com)
-- [`Yarn 2+`](https://yarnpkg.com)
+- [npm](https://docs.npmjs.com/cli/v10/commands/npm)
+- [pnpm](https://pnpm.io)
+- [Yarn 1](https://classic.yarnpkg.com)
+- [Yarn 2+](https://yarnpkg.com)
 
 Cloud Engine will automatically detect the package manager based on these conditions:
 
-| Package Manager | Condition                                                                                                | Version                      |
-| --------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------- |
-| pnpm            | A valid `pnpm-lock.yaml` exists                                                                          |                              |
-|                 | `lockfileVersion: '6.0'` or higher                                                                       | 8                            |
-|                 | `lockfileVersion: 5.3` or higher                                                                         | 7                            |
-|                 | Otherwise                                                                                                | 6                            |
-| Yarn 1          | `yarn.lock` exists                                                                                       | 1                            |
-| Yarn 2+         | Not supported by default, enable via [Corepack](/sdk/engine/deploy/nodejs#experimental-corepack-support) | 2+                           |
-| npm             | Otherwise                                                                                                | npm with the Node.js is used |
+| Package Manager | Condition                                                                       | Version                      |
+| --------------- | ------------------------------------------------------------------------------- | ---------------------------- |
+| pnpm            | A valid `pnpm-lock.yaml` exists                                                 |                              |
+|                 | `lockfileVersion: '6.0'` or higher                                              | 8                            |
+|                 | `lockfileVersion: 5.3` or higher                                                | 7                            |
+|                 | Otherwise                                                                       | 6                            |
+| Yarn 1          | `yarn.lock` exists                                                              | 1                            |
+| Yarn 2+         | Not supported by default, enable via [Corepack](#experimental-corepack-support) | 2+                           |
+| npm             | Otherwise                                                                       | npm with the Node.js is used |
 
 ### Experimental Corepack support
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/sdk/engine/deploy/nodejs.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/sdk/engine/deploy/nodejs.mdx
@@ -13,6 +13,7 @@ import CloudFilesystem from "../_partials/cloud-filesystem.mdx";
 import BuildingAdvanced from "../_partials/building-advanced.mdx";
 import BuildingBuildLogs from "../_partials/building-build-logs.mdx";
 import NodejsSetupRuntime from "../_partials/nodejs-setup-runtime.mdx";
+import NodejsSetupPackageManager from "../_partials/nodejs-setup-package-manager.mdx";
 import NodejsSetupDependencies from "../_partials/nodejs-setup-dependencies.mdx";
 import CloudCustomDomain from "../_partials/cloud-custom-domain.mdx";
 import CloudHealthCheck from "../_partials/cloud-health-check.mdx";
@@ -65,6 +66,10 @@ When debugging locally by running `lean up` with the [CLI](/sdk/engine/cli), the
 
 <NodejsSetupRuntime />
 
+## Configure Package Manager
+
+<NodejsSetupPackageManager />
+
 ## Install Dependencies (`package.json`)
 
 <NodejsSetupDependencies />
@@ -79,8 +84,8 @@ When debugging locally by running `lean up` with the [CLI](/sdk/engine/cli), the
 install:
   - use: default
   - require:
-    - ./frontend/package.json
-    - ./frontend/package-lock.json
+      - ./frontend/package.json
+      - ./frontend/package-lock.json
   - cd frontend && npm ci
 build:
   - npm run build
@@ -134,7 +139,7 @@ Here we keep the default behavior and install dependencies and run build command
 ### Why are the dependencies listed under `devDependencies` not installed?
 
 When you deploy your project, Cloud Engine will install dependencies (including those listed under `devDependencies`) for your project with `npm ci`.
-However, if the Node.js version you specified is below 10, Cloud Engine will use `npm install --production` instead. This means that the dependencies listed under `devDependencies` will **not** be installed.
+However, if the Node.js version you specified is below 10 or lockfile not exists, Cloud Engine will use `npm install --production` instead. This means that the dependencies listed under `devDependencies` will **not** be installed, see [Default Commands](/sdk/engine/deploy/nodejs#Default+Commands).
 To have these dependencies installed as well, you can specify `installDevDependencies: true` in `leanengine.yaml`.
 
 ### What should I do if I see `npm ERR! peer dep missing`?

--- a/i18n/en/docusaurus-plugin-content-docs/current/sdk/engine/deploy/nodejs.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/sdk/engine/deploy/nodejs.mdx
@@ -84,8 +84,8 @@ When debugging locally by running `lean up` with the [CLI](/sdk/engine/cli), the
 install:
   - use: default
   - require:
-      - ./frontend/package.json
-      - ./frontend/package-lock.json
+    - ./frontend/package.json
+    - ./frontend/package-lock.json
   - cd frontend && npm ci
 build:
   - npm run build

--- a/i18n/en/docusaurus-plugin-content-docs/current/sdk/engine/deploy/webapp.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/sdk/engine/deploy/webapp.mdx
@@ -6,6 +6,7 @@ sidebar_position: 3
 
 import CloudTimezone from "../_partials/cloud-timezone.mdx";
 import NodejsSetupRuntime from "../_partials/nodejs-setup-runtime.mdx";
+import NodejsSetupPackageManager from "../_partials/nodejs-setup-package-manager.mdx";
 import BuildingAdvanced from "../_partials/building-advanced.mdx";
 import BuildingBuildLogs from "../_partials/building-build-logs.mdx";
 import NodejsSetupDependencies from "../_partials/nodejs-setup-dependencies.mdx";
@@ -109,6 +110,10 @@ The build process can be run on Cloud Engine so you don’t have to include a pr
 ## Configure Node.js Version
 
 <NodejsSetupRuntime />
+
+## Config Package Manager
+
+<NodejsSetupPackageManager />
 
 ## Install Dependencies (`package.json`)
 


### PR DESCRIPTION
云引擎给 Node.js 运行时添加了 Corepack 支持，修改文档