### PR TITLE
docs:Change of primary to secondary headings

### DIFF
--- a/docs/sdk/copyright-verification/guide.mdx
+++ b/docs/sdk/copyright-verification/guide.mdx
@@ -18,7 +18,7 @@ import UnitySDKInstallation from "../_partials/unity-sdk-installation.mdx";
 - 如已购买，则可正常进入游戏。
 - 如查询到未购买，将出现「游戏未激活，请前往 TapTap 购买此游戏」弹窗，玩家必须选择「打开 TapTap」购买之后才能游玩。
 
-# 付费下载
+## 付费下载
 
 ## 权限说明
 
@@ -239,7 +239,7 @@ FTapLicense::Check(true);
 
 <AndroidFaq />
 
-# DLC
+## DLC
 
 ## 权限说明
 


### PR DESCRIPTION
- 正版验证将「付费下载」和「DLC」由一级目录更改成二级目录，方便锚定快速定位。