### PR TITLE
docs: move old update to shadow

### DIFF
--- a/docs/shadow/tap-update-old-guide.mdx
+++ b/docs/shadow/tap-update-old-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 唤起更新开发指南
+slug: /tap-update-old-guide/
 ---
 
 <head>
@@ -10,7 +11,7 @@ import MultiLang from "/src/docComponents/MultiLang";
 import CodeBlock from "@theme/CodeBlock";
 import sdkVersions from "/src/docComponents/sdkVersions";
 import { Conditional } from "/src/docComponents/conditional";
-import AndroidFaq from "./sdk/_partials/android-package-visibility.mdx";
+import AndroidFaq from "../sdk/_partials/android-package-visibility.mdx";
 
 TapTap 开发者服务为游戏和玩家提供唤起 TapTap 客户端更新游戏的功能。
 


### PR DESCRIPTION
- 将早期的更新唤起文档进行隐藏，避免 AI 客服团队读取进行训练