### PR TITLE
docs: the use of the test accounts depends on unionid

### DIFF
--- a/docs/sdk/anti-addiction/guide.mdx
+++ b/docs/sdk/anti-addiction/guide.mdx
@@ -995,7 +995,9 @@ int RemainingTimeInMinutes = AntiAddictionUE::GetRemainingTimeInMinutes();    //
 
 使用提供的测试账号以邮箱方式登录 TapTap，游戏启动后触发 TapTap 登录，登录成功后会在成功的回调中得到当前测试账号对应的 `unionid`， `unionid` 获取方式可以参考[获取用户信息](/sdk/taptap-login/guide/start/#获取用户信息)的内容。
 
-开启测试模式的接口需要在 SDK 的 `init` 初始化接口之后，`startupwithtaptap` 接口之前调用。在 `startupwithtaptap` 传入的 **玩家唯一标识** `userIdentifier` 必须为测试账号对应的 TapTap 登录后返回的 `unionid`。
+开启测试模式的接口需要在 SDK 的 `init` 初始化接口之后，`startupwithtaptap` 接口之前调用。
+
+测试账号的使用场景分为两种：**常规模式** 和 **测试模式**。无论是常规模式还是测试模式，在 `startupwithtaptap` 传入的 **玩家唯一标识** `userIdentifier` 皆必须为测试账号对应的 TapTap 登录后返回的 `unionid`。
 
 
 <MultiLang kind="ue">


### PR DESCRIPTION
- 测试账号的使用无论常规模式还是测试模式皆强依赖于 unionid。