### PR TITLE
docs: optimise documentation details

### DIFF
--- a/versioned_docs/version-v4/sdk/access/get-ready.mdx
+++ b/versioned_docs/version-v4/sdk/access/get-ready.mdx
@@ -1,5 +1,5 @@
 ---
-title: DC 控制台配置
+title: 开发者中心配置
 sidebar_position: 0
 ---
 

--- a/versioned_docs/version-v4/sdk/access/quickstart.mdx
+++ b/versioned_docs/version-v4/sdk/access/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: TapSDK集成
-sidebar_label: TapSDK集成
+sidebar_label: TapSDK 集成
 sidebar_position: 1
 ---
 

--- a/versioned_docs/version-v4/sdk/achievement/features.mdx
+++ b/versioned_docs/version-v4/sdk/achievement/features.mdx
@@ -84,7 +84,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 白金徽章：开通白金成就后，TapTap会为游戏定制专属的白金徽章，当用户解锁白金成就时，也能佩戴上对应的白金徽章。
 
 
-https://img.tapimg.com/market/images/2b9b2064064438b48baf7104c4ddc59f.png
+![](https://img.tapimg.com/market/images/2b9b2064064438b48baf7104c4ddc59f.png)
 
 
 
@@ -100,7 +100,7 @@ https://img.tapimg.com/market/images/2b9b2064064438b48baf7104c4ddc59f.png
 填写成就的相关信息，点击**保存**，这个成就进入到**审核中**状态。审核通过后状态会置为**待发布**，审核不通过后状态会置为**已驳回**。
 
 
-https://img.tapimg.com/market/images/47ad5af3b10a6996ed8eec096cec71e6.png
+![](https://img.tapimg.com/market/images/47ad5af3b10a6996ed8eec096cec71e6.png)
 
 
 
@@ -120,7 +120,7 @@ https://img.tapimg.com/market/images/47ad5af3b10a6996ed8eec096cec71e6.png
 5. 在发布前，仅「游戏管理员」和「测试人员」可以预览成就用户端的页面，确保配置和数据上报正确。
 
 
-https://img.tapimg.com/market/images/e1edfee896b0fffa9883a9a03e70055f.png
+![](https://img.tapimg.com/market/images/e1edfee896b0fffa9883a9a03e70055f.png)
 
 
 ### 发布普通成就
@@ -145,7 +145,7 @@ https://img.tapimg.com/market/images/e1edfee896b0fffa9883a9a03e70055f.png
 为了确保白金成就的挑战性，开发者需要创建 10 个**白金解锁条件**内的普通成就后，才能创建白金成就，提交时需要配置**图标**、**名称**和**简介**，当白金成就审核通过后，就可以发布了。
 
 
-https://img.tapimg.com/market/images/51dbdb84c2bd00ce20b2f0532683aaf6.png
+![](https://img.tapimg.com/market/images/51dbdb84c2bd00ce20b2f0532683aaf6.png)
 
 
 ### 白金成就审核标准
@@ -214,7 +214,7 @@ https://img.tapimg.com/market/images/51dbdb84c2bd00ce20b2f0532683aaf6.png
 - 开发者对于游戏内的成就展示页和冒泡通知可以选择显示或隐藏。
 
 
-https://img.tapimg.com/market/images/3178576661340ec4768fcb1498048e58.png
+![](https://img.tapimg.com/market/images/3178576661340ec4768fcb1498048e58.png)
 
 
 ### 游戏内查看成就
@@ -231,7 +231,7 @@ https://img.tapimg.com/market/images/3178576661340ec4768fcb1498048e58.png
 - TapTap 登录游戏：使用 TapTap 登录的玩家可以直接在 「TapTap 客户端-我的-游戏成就」查看已解锁和未解锁的游戏成就。
 - 非 TapTap 登录游戏：如果游戏本身存在账号体系，需要游戏自己绘制一个 TapTap 账号绑定入口，将游戏账号和 TapTap 账号关联起来，将成就数据同步到 TapTap 上。
 
-https://img.tapimg.com/market/images/2139f3837e93b40a55bde28b899e08e8.png
+![](https://img.tapimg.com/market/images/2139f3837e93b40a55bde28b899e08e8.png)
 
 
 :::tip 
@@ -253,7 +253,7 @@ https://img.tapimg.com/market/images/2139f3837e93b40a55bde28b899e08e8.png
 
 ### 接入流程
 
-https://img.tapimg.com/market/images/a3f191811eab92fad8bb43d325346d08.png
+![](https://img.tapimg.com/market/images/a3f191811eab92fad8bb43d325346d08.png)
 
 ### 接入指南
 
@@ -293,6 +293,3 @@ https://img.tapimg.com/market/images/a3f191811eab92fad8bb43d325346d08.png
 #### 游戏有多个区服或可以创建多个角色，如果重复获得成就，SDK 的逻辑是怎样的？
 
 成就记录跟着账号走，每个成就只记录第一次获得的行为，之后重复获得将不做展示。
-
-
-

--- a/versioned_docs/version-v4/sdk/taptap-login/_category_.json
+++ b/versioned_docs/version-v4/sdk/taptap-login/_category_.json
@@ -1,5 +1,5 @@
 {
   "label": "TapTap 登录",
   "collapsed": true,
-  "position": 3
+  "position": 2
 }

--- a/versioned_docs/version-v4/sdk/update/_category_.json
+++ b/versioned_docs/version-v4/sdk/update/_category_.json
@@ -1,5 +1,5 @@
 {
   "label": "更新唤起",
   "collapsed": true,
-  "position": 2
+  "position": 3
 }


### PR DESCRIPTION
- 「DC 控制台配置」，适合改名为「开发者中心配置」
- 修复成就图片展示异常
- 排序上：「TapTap 登录」移动至「更新唤起」之上