### PR TITLE
docs: remove obsolete descriptions for taplogin checkoutlist module

### DIFF
--- a/cn/docs/sdk/taptap-login/best-practice.mdx
+++ b/cn/docs/sdk/taptap-login/best-practice.mdx
@@ -44,7 +44,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 向玩家提供登录功能前，开发者需要测试登录流程是否正常完成，检查以下事项：
 
 * 游戏是否达到 [SDK 环境要求](/sdk/access/quickstart/#环境要求)。
-* 开发者是否了解 TapSDK 中两种 TapTap 登录方式，并选择了适合游戏的一种。参考[接入 TapTap 登录](/sdk/taptap-login/guide/)。
 * 是否在 TapTap 开发者后台填写了 Android 平台或 iOS 平台相关配置。参考[配置签名证书](/sdk/access/get-ready/#配置签名证书)。
 * 在未安装 TapTap 客户端的设备上打开游戏，是否能以 WebView 方式完成登录流程，是否能获取玩家授权的基本信息。
 * 在安装了最新版 TapTap 客户端的设备上打开游戏，是否能拉起 TapTap 客户端完成登录流程，是否能获取玩家授权的基本信息。

--- a/hk/docs/sdk/taptap-login/best-practice.mdx
+++ b/hk/docs/sdk/taptap-login/best-practice.mdx
@@ -44,7 +44,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 向玩家提供登录功能前，开发者需要测试登录流程是否正常完成，检查以下事项：
 
 * 游戏是否达到 [SDK 环境要求](/sdk/access/quickstart/#环境要求)。
-* 开发者是否了解 TapSDK 中两种 TapTap 登录方式，并选择了适合游戏的一种。参考[接入 TapTap 登录](/sdk/taptap-login/guide/)。
 * 是否在 TapTap 开发者后台填写了 Android 平台或 iOS 平台相关配置。参考[配置签名证书](/sdk/access/get-ready/#配置签名证书)。
 * 在未安装 TapTap 客户端的设备上打开游戏，是否能以 WebView 方式完成登录流程，是否能获取玩家授权的基本信息。
 * 在安装了最新版 TapTap 客户端的设备上打开游戏，是否能拉起 TapTap 客户端完成登录流程，是否能获取玩家授权的基本信息。

--- a/hk/i18n/en/docusaurus-plugin-content-docs/current/sdk/taptap-login/best-practice.mdx
+++ b/hk/i18n/en/docusaurus-plugin-content-docs/current/sdk/taptap-login/best-practice.mdx
@@ -44,7 +44,6 @@ If the game has its own account system and only uses simple TapTap login, the ga
 Before providing login functionality to players, developers need to test whether the login process is completed normally and check the following items:
 
 * Does the game meet the [SDK Environment Requirements](/sdk/access/quickstart/#environment-requirements)?
-* Do developers understand the two TapTap login methods in TapSDK and have they chosen one suitable for the game? Refer to [Integrating TapTap Login](/sdk/taptap-login/guide/).
 * Have the relevant configurations for the Android platform or iOS platform been filled out in the TapTap Developer Backend? Refer to [Configure Signature Certificate](/sdk/access/get-ready/#configure-signature-certificate).
 * On a device without the TapTap client installed, can the login process be completed using the WebView method, and can the player's authorized basic information be obtained?
 * On a device with the latest TapTap client installed, can the TapTap client be launched to complete the login process, and can the player's authorized basic information be obtained?


### PR DESCRIPTION
- 登录模块去除 Checklist 中过时的描述项；